### PR TITLE
updated files for deploying to developer docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,31 +1,23 @@
-# Table of Contents
-1. [Deployment architecture](#deployment-architecture)
-2. [Deploy Citrix ADC as an Ingress Gateway](#deploy-citrix-adc-as-an-ingress-gateway)
-3. [Deploy Citrix ADC CPXs as sidecars](#deploy-citrix-adc-cpxs-as-sidecars)
 
-# <a name="deployment-architecture">Deployment architecture</a>
+# Deployment architecture
 
 The Istio service mesh can be logically divided into control plane and data plane components. The data plane is composed of a set of proxies which manage the network traffic between instances of the service mesh. The control plane generates and deploys the configuration that controls the data plane's behavior.
 For detailed information on Istio architecture and different components, see [Istio docs](https://istio.io/docs/concepts/what-is-istio/#architecture).
 
-## Integration with Istio Control Plane Components
+## Integration with Istio control plane components
 
-The Istio control plane is a set of gRPC based services and it pushes configuration changes to clients listening at the data plane. Pilot, Mixer, Galley and Citadel are important control plane components. Out of these, data plane proxy primarily needs to interact with Pilot, Mixer and Citadel.
+The Istio control plane is a set of gRPC based services and it pushes configuration changes to clients listening at the data plane. Pilot, Mixer, Galley, and Citadel are important control plane components. Out of these components, data plane proxy primarily needs to interact with Pilot, Mixer, and Citadel.
  
-**Pilot** is a gRRPC based xDS server and provides configuration data to proxies. Citrix provides an xDS client called `istio-adaptor` to communicate with this Istio control plane component for installing Citrix ADCs in Istio service mesh. `istio-adaptor` acts as a gRPC client to the control plane API server and listens to updates. Based on the updates from the control plane, `istio-adaptor` generates the equivalent Citrix ADC configuration. Then, it configures the Citrix ADC ingress or proxy device accordingly.
+**Pilot** is a gRRPC based xDS server and provides configuration data to proxies. Citrix provides an xDS client called `istio-adaptor` to communicate with this Istio control plane component for installing Citrix ADCs in Istio service mesh. It acts as a gRPC client to the control plane API server and listens to updates. Based on the updates from the control plane, `istio-adaptor` generates the equivalent Citrix ADC configuration. Then, it configures the Citrix ADC ingress or proxy device accordingly.
 
-**Citadel** is a control plane service which provides key and certificate management. It is responsible for providing TLS certificates to data plane proxies. `istio-adaptor` monitors secrets managed by Citadel, and updates the Citrix ADC proxy with relevant details.
+**Citadel** is a control plane service which provides key and certificate management. It is responsible for providing TLS certificates to data plane proxies. Citrix `istio-adaptor` monitors secrets managed by Citadel, and updates the Citrix ADC proxy with relevant details.
 
 **Mixer** primarily performs two tasks:
 
-i) Collecting telemetry data from services 
+- collects telemetry data from services
+- checks policies and enforces access control across the mesh
 
-ii) Policy checks and access control across the mesh
-
-Citrix service mesh solution does not interact with the Mixer component. It provides its own [Citrix ADC Metrics Exporter](https://github.com/citrix/citrix-adc-metrics-exporter) which collects the statistical data from Citrix ADC Ingress Gateway device and exports to the [Prometheus](https://prometheus.io). Citrix is working on a solution to perform telemetry collection from Citrix CPX sidecar proxies, and it will be available in future releases. 
-
-As of now, Citrix service mesh solution lacks the support of policy check. It will also be part of future releases.
-
+Citrix service mesh solution does not interact with the Mixer component. It provides a container, [Citrix ADC Metrics Exporter](https://github.com/citrix/citrix-adc-metrics-exporter), which collects the statistical data from Citrix ADC Ingress Gateway device and exports it to [Prometheus](https://prometheus.io).
 
 Citrix ADC can be integrated with Istio in two ways:
 
@@ -34,8 +26,7 @@ Citrix ADC can be integrated with Istio in two ways:
 Both modes can be combined to have a unified data plane solution.
 
 
-  
-## <a name="deploy-citrix-adc-as-an-ingress-gateway">Deploy Citrix ADC as an Ingress Gateway</a>
+## Deploy Citrix ADC as an Ingress Gateway
 
 An Istio Ingress Gateway acts as an entry point for the incoming traffic to the service mesh. It secures and controls access to the service mesh from outside. You can deploy a Citrix ADC CPX, MPX, or VPX as an ingress Gateway to the Istio service mesh.
 
@@ -48,19 +39,21 @@ The following diagram shows a sample deployment of Citrix ADC CPX as an Ingress 
 
 ![CPX-ingress](media/CPX-ingress.jpeg)
 
-For detailed instructions on how to deploy Citrix ADC CPX as an Ingress Gateway, see [Deploying Citrix ADC with Istio](../deployment/README.md).
+For detailed instructions on how to deploy Citrix ADC CPX as an Ingress Gateway, see [Deploying Citrix ADC with Istio](deploy-istio-adaptor-yaml.md).
 
 ### Citrix ADC MPX or VPX as an Ingress Gateway
 
-Citrix ADC VPX or MPX can be deployed as an Ingress Gateway to the Istio service mesh. In this deployment, a Kubernetes pod is deployed with an `istio-adaptor` container. The `istio-adaptor` container connects to the Istio control pane and reads the ingress configuration and then configures the Citrix ADC VPX or MPX accordingly. For this deployment, <b>you should establish the connectivity between the concerned Citrix ADC and the cluster nodes</b>.
+Citrix ADC VPX or MPX can be deployed as an Ingress Gateway to the Istio service mesh. In this deployment, a Kubernetes pod is deployed with an `istio-adaptor` container. The `istio-adaptor` container connects to the Istio control pane and reads the ingress configuration and then configures the Citrix ADC VPX or MPX accordingly.
+
+**Note:** For this deployment, you should establish the connectivity between the concerned Citrix ADC and the cluster nodes.
 
 The following diagram shows a sample deployment of Citrix ADC VPX/MPX as an ingress Gateway.
 
 ![vpx-ingress](media/vpx-ingress.jpeg)
 
-For detailed instructions on how to deploy Citrix ADC VPX or MPX as an Ingress Gateway, see [Deploying Citrix ADC with Istio](../deployment/README.md).
+For detailed instructions on how to deploy Citrix ADC VPX or MPX as an Ingress Gateway, see [Deploying Citrix ADC with Istio](deploy-istio-adaptor-yaml.md).
 
-## <a name="deploy-citrix-adc-cpxs-as-sidecars">Deploy Citrix ADC CPXs as sidecars</a>
+## Deploy Citrix ADC CPXs as sidecars
 
 Citrix ADC CPX can be deployed as a sidecar proxy in application pods. It intercepts all the incoming and outgoing traffic from the application pod and applies the configured routing policies or rules.
 
@@ -71,4 +64,4 @@ The following diagram shows a sample deployment of Citrix ADC CPXs as sidecars.
 
 ![cpx-proxy](media/cpx-proxy.jpeg)
 
-For detailed instructions on how to deploy Citrix ADC CPX as a sidecar, see [Deploying Citrix ADC with Istio](../deployment/README.md).
+For detailed instructions on how to deploy Citrix ADC CPX as a sidecar, see [Deploying Citrix ADC with Istio](deploy-istio-adaptor-yaml.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,9 @@ The Istio control plane is a set of gRPC based services and it pushes configurat
 
 Citrix service mesh solution does not interact with the Mixer component. It provides a container, [Citrix ADC Metrics Exporter](https://github.com/citrix/citrix-adc-metrics-exporter), which collects the statistical data from Citrix ADC Ingress Gateway device and exports it to [Prometheus](https://prometheus.io).
 
+Citrix also provides its own in-house solution `Citrix Observability Exporter` for the telemetry purpose. Citrix ADC CPX running as a sidecar proxy interacts with the Citrix Observability Exporter (COE). Citrix ADC CPX sends metrics and transactions to COE. COE supports endpoints such as Zipkin and Prometheus, and sends the data collected from sidecar proxies to these endpoints in appropriate format.
+
+
 Citrix ADC can be integrated with Istio in two ways:
 
 -  Citrix ADC CPX, MPX, or VPX as an Ingress Gateway to the service mesh

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ The Istio control plane is a set of gRPC based services and it pushes configurat
 
 Citrix service mesh solution does not interact with the Mixer component. It provides a container, [Citrix ADC Metrics Exporter](https://github.com/citrix/citrix-adc-metrics-exporter), which collects the statistical data from Citrix ADC Ingress Gateway device and exports it to [Prometheus](https://prometheus.io).
 
-Citrix also provides its own in-house solution `Citrix Observability Exporter` for the telemetry purpose. Citrix ADC CPX running as a sidecar proxy interacts with the Citrix Observability Exporter (COE). Citrix ADC CPX sends metrics and transactions to COE. COE supports endpoints such as Zipkin and Prometheus, and sends the data collected from sidecar proxies to these endpoints in appropriate format.
+Citrix also provides its own in-house solution [Citrix Observability Exporter](https://github.com/citrix/citrix-observability-exporter) for the telemetry purpose. Citrix ADC CPX running as a sidecar proxy interacts with the Citrix Observability Exporter (COE). Citrix ADC CPX sends metrics and transactions to COE. COE supports endpoints such as Zipkin and Prometheus, and sends the data collected from sidecar proxies to these endpoints in appropriate format.
 
 
 Citrix ADC can be integrated with Istio in two ways:

--- a/docs/cpx-licensing.md
+++ b/docs/cpx-licensing.md
@@ -1,6 +1,6 @@
 # Licensing
 
-For licensing the Citrix ADC CPX, you need to provide the following information in the YAML file. This information is required for automatically picking the licensing information. The license server runs in the [Citrix ADM](https://docs.citrix.com/en-us/citrix-application-delivery-management-service.html).
+For licensing Citrix ADC CPX, you need to provide the following information in the YAML file. This information is required for automatically picking the licensing information. The license server runs in the [Citrix ADM](https://docs.citrix.com/en-us/citrix-application-delivery-management-service.html).
 
 -  **LS_IP (License Server IP)** – Specify the License Server IP address(for example: Citrix ADM IP address).
 
@@ -40,4 +40,4 @@ spec:
 ---
 ```    
 
-The complete yaml file can be found [here](../deployment/cpx-ingressgateway.tmpl).
+The complete YAML file can be found [here](https://github.com/citrix/citrix-istio-adaptor/blob/master/deployment/cpx-ingressgateway.tmpl).

--- a/docs/deploy-istio-adaptor-helm-chart.md
+++ b/docs/deploy-istio-adaptor-helm-chart.md
@@ -1,21 +1,24 @@
-# Citrix ADC CPX in Istio Helm Chart
+# Citrix ADC CPX in Istio Helm chart
 
-This repository contains [helm](https://helm.sh) charts for installing Citrix ADC CPX as Ingress Gateway and sidecar proxy in [Istio](https://istio.io)v1.3.0.
+The [Citrix `istio-adaptor` repository](https://github.com/citrix/citrix-istio-adaptor) contains [Helm](https://helm.sh) charts for installing Citrix ADC CPX as Ingress Gateway and sidecar proxy in [Istio](https://istio.io) version 1.3.0.
 
 
-> Note: Charts may require access to kube-system namespace and/or cluster wide permissions for full functionality. Install/configure helm/tiller appropriately.
+> **Note:** Charts may require access to `kube-system` namespace and may need cluster wide permissions for full functionality. You must install and configure Helm client and Tiller.
 
-## Helm Installation
-Please refer [Helm Installation Guide](https://github.com/citrix/citrix-helm-charts/blob/master/Helm_Installation_Kubernetes.md)
+## Helm installation
 
-## Stable Charts
+For more information, see [Helm Installation Guide](https://github.com/citrix/citrix-helm-charts/blob/master/Helm_Installation_Kubernetes.md).
+
+## Stable charts
+
 The stable directory contains charts that are created and tested by Citrix.
 
-###### Charts
-[citrix-adc-istio-ingress-gateway](https://github.com/citrix/citrix-helm-charts/tree/master/citrix-adc-istio-ingress-gateway) -Use this chart to deploy Citrix ADC as Ingress Gateway in Istio environment.
+### Charts
 
-[citrix-cpx-istio-sidecar-injector](https://github.com/citrix/citrix-helm-charts/tree/master/citrix-cpx-istio-sidecar-injector) -Use this chart to deploy resources responsible for injecting Citrix ADC CPX as sidecar in Istio Service Mesh.
+[`citrix-adc-istio-ingress-gateway`](https://github.com/citrix/citrix-helm-charts/tree/master/citrix-adc-istio-ingress-gateway) -Use this chart to deploy Citrix ADC as Ingress Gateway in Istio environment.
 
+[`citrix-cpx-istio-sidecar-injector`](https://github.com/citrix/citrix-helm-charts/tree/master/citrix-cpx-istio-sidecar-injector) -Use this chart to deploy resources responsible for injecting Citrix ADC CPX as sidecar in Istio Service Mesh.
 
 ## Documentation
+
 Chart's README describes the functionality and values.yaml shows the default values.

--- a/docs/deploy-istio-adaptor-yaml.md
+++ b/docs/deploy-istio-adaptor-yaml.md
@@ -24,18 +24,24 @@ The following output indicates that the API is enabled:
 
 You can deploy Citrix ADC CPX as an Ingress Gateway in the Istio environment. In this deployment, `generate_yaml.sh` script is used to create a YAML file from the `cpx-ingressgateway.tmpl` template. This newly created YAML file is used to deploy Citrix ADC CPX in a Kubernetes namespace. Citrix ADC can act as an Ingress Gateway for standalone services or services deployed along with sidecar proxy (Envoy or Citrix CPX).
 To deploy Citrix ADC CPX as an Ingress Gateway, perform the following steps.
+
+
 1.  Download the `generate_yaml.sh` script.
 
         curl -L https://raw.githubusercontent.com/citrix/citrix-istio-adaptor/master/deployment/generate_yaml.sh > generate_yaml.sh
+
 2.  Change the permissions of the script to executable mode.
 
         chmod +x generate_yaml.sh
+
 3.  Download the ``cpx-ingressgateway.tmpl`` template.
 
         curl -L https://raw.githubusercontent.com/citrix/citrix-istio-adaptor/master/deployment/cpx-ingressgateway.tmpl > cpx-ingressgateway.tmpl
+
 4.  Create a YAML file from the template using the generate_yaml.sh script.
    
         ./generate_yaml.sh --inputfile cpx-ingressgateway.tmpl --outputfile cpx-ingressgateway.yaml
+       
        > **Note:**
        >To use particular images for Citrix ADC CPX and istio-adaptor, you can provide image details to the `generate_yaml.sh` script using cpx-image-name and istio-adaptor-image-name arguments. You can also provide licensing server IP address and port information using license-server-ip and license-server-port arguments.
   
@@ -43,6 +49,7 @@ To deploy Citrix ADC CPX as an Ingress Gateway, perform the following steps.
 
 
         ./generate_yaml.sh --inputfile cpx-ingressgateway.tmpl --outputfile cpx-ingressgateway.yaml --cpx-image-name quay.io/citrix/citrix-k8s-cpx-ingress --cpx-image-tag 13.0-47.22 --istio-adaptor-image-name quay.io/citrix/citrix-istio-adaptor --istio-adaptor-image-tag 1.2.0 --license-server-ip 192.168.1.10 --license-server-port 27000
+
 5.  Deploy Citrix ADC CPX using the YAML file and specify the name space.
        
         kubectl create -f cpx-ingressgateway.yaml -n citrix-system
@@ -55,30 +62,38 @@ To deploy Citrix ADC MPX or VPX as an Ingress Gateway, perform the following:
 1.  Download the `generate_yaml.sh` script.
    
         curl -L https://raw.githubusercontent.com/citrix/citrix-istio-adaptor/master/deployment/generate_yaml.sh > generate_yaml.sh
+
 1.  Change permissions of the script to executable mode.
    
         chmod +x generate_yaml.sh
+
 1.  Download the `ingressgateway.tmpl` template.
    
         curl -L https://raw.githubusercontent.com/citrix/citrix-istio-adaptor/master/deployment/ingressgateway.tmpl > ingressgateway.tmpl
+
 1.  Download the `secret.tmpl` YAML file template.
    
         curl -L https://raw.githubusercontent.com/citrix/citrix-istio-adaptor/master/deployment/secret.tmpl > secret.tmpl
+
 1.  Generate the Kubernetes secret YAML file from the `secret.tmpl`template for Citrix ADC VPX or MPX credentials.
 
         ./generate_yaml.sh --inputfile secret.tmpl --outputfile secret.yaml --username <username> --password <password>
+
 1.  Create the Kubernetes secret object in the cluster.
 
         kubectl create -f secret.yaml -n citrix-system
+
 1.  Create a YAML file from the `ingressgateway.tmpl` template using the generate_yaml.sh script.
    
-        ./generate_yaml.sh --inputfile ingressgateway.tmpl --outputfile ingressgateway.yaml --netscaler-url https://<nsip>[:port] --vserver-ip <Virtual Server IPv4 Address>
+         ./generate_yaml.sh --inputfile ingressgateway.tmpl --outputfile ingressgateway.yaml --netscaler-url https://<nsip>[:port] --vserver-ip <Virtual Server IPv4 Address>
+   
     >**Note:**
     >To use a specific image for `istio-adaptor`, you can provide image details to the `generate_yaml.sh` script using the `istio-bdg-image-name` argument.
    
     The following example shows how to specify the image details while running the script to create the YAML file.
 
           ./generate_yaml.sh --inputfile ingressgateway.tmpl --outputfile ingressgateway.yaml --istio-adaptor-image-name quay.io/citrix/citrix-istio-adaptor --istio-adaptor-image-tag 1.2.0 --netscaler-url https://<nsip>[:port]
+
 1. Deploy Citrix ADC VPX or MPX using the `ingressgateway.yaml` file and specify the name space.
        kubectl create -f ingressgateway.yaml -n citrix-system
 
@@ -111,6 +126,7 @@ You must create the resources required for automatic sidecar injection by perfor
 2.  Change the permissions of the script to executable mode.
 
         chmod +x webhook-create-signed-cert.sh
+
 3.  Create a signed certificate, key pair and store it in a Kubernetes secret.
 
         ./webhook-create-signed-cert.sh \

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,6 +1,6 @@
 # Features supported according to Istio resources
 
-The detailed list of fields supported on Citrix ADC as per the Istio CRDs (Destination Rule, Virtual Service, Policy, Gateway, Service Entry) is mentioned below.
+The detailed list of fields supported on Citrix ADC as per the Istio CRDs (Destination Rule, Virtual Service, Policy, Gateway, Service Entry) is specified as follows:
 
 ## [Destination Rule](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/)
 
@@ -10,30 +10,30 @@ The following table describes the destination rule settings supported by Citrix 
 
 | Field                                                      | Istio-adaptor version| Citrix ADC Version |
 |------------------------------------------------------------|---------------|-----------------------|
-| [trafficPolicy.connectionPool.tcp.maxConnections](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#ConnectionPoolSettings-TCPSettings)          | 1.0.0+ | 13.0-37.16+  |
-| [trafficPolicy.connectionPool.http.http2MaxRequests](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#ConnectionPoolSettings-HTTPSettings)       | 1.0.0+ | 13.0-37.16+ | 
-| [trafficPolicy.connectionPool.http.maxRequestsPerConnection](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#ConnectionPoolSettings-HTTPSettings) | 1.0.0+ | 13.0-37.16+  | 
-| [trafficPolicy.loadBalancer.simple = ROUND_ROBIN](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#LoadBalancerSettings-SimpleLB)           | 1.0.0+ | 13.0-37.16+  | 
-| [trafficPolicy.loadBalancer.simple = LEAST_CONN](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#LoadBalancerSettings-SimpleLB)          | 1.0.0+                     | 13.0-37.16+  | 
-| [trafficPolicy.loadBalancer.simple = RANDOM](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#LoadBalancerSettings-SimpleLB)               | 1.0.0+          | 13.0-37.16+  | 
-| [trafficPolicy.loadBalancer.consistentHash.httpHeaderName](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#LoadBalancerSettings-ConsistentHashLB)  | 1.0.0+  | 13.0-37.16+  | 
-| [trafficPolicy.loadBalancer.consistentHash.httpCookie.name](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#LoadBalancerSettings-ConsistentHashLB) | 1.0.0+   | 13.0-37.16+  | 
-| [trafficPolicy.loadBalancer.consistentHash.httpCookie.ttl](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#LoadBalancerSettings-ConsistentHashLB-HTTPCookie)   |  1.0.0+ | 13.0-37.16+  | 
-| [trafficPolicy.loadBalancer.consistentHash.useSourceIp](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#LoadBalancerSettings-ConsistentHashLB)      | 1.0.0+     | 13.0-37.16+  | 
-| [trafficPolicy.tls.mode = DISABLE](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#TLSSettings-TLSmode)                          | 1.0.0+  | 13.0-37.16+  | 
-| [trafficPolicy.tls.mode = SIMPLE](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#TLSSettings-TLSmode)                         | 1.0.0+   | 13.0-37.16+  | 
-| [trafficPolicy.tls.mode = MUTUAL](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#TLSSettings-TLSmode)                           | 1.0.0+    | 13.0-37.16+  | 
-| [trafficPolicy.tls.mode = ISTIO_MUTUAL](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#TLSSettings-TLSmode)                      | 1.0.0+           | 13.0-37.16+  | 
-| [trafficPolicy.tls.clientCertificate](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#TLSSettings)                         | 1.0.0+          | 13.0-37.16+  | 
-| [trafficPolicy.tls.mode = MUTUAL](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#TLSSettings-TLSmode)                                 | 1.0.0+         | 13.0-37.16+ |
-| [trafficPolicy.tls.privateKey](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#TLSSettings)                               | 1.0.0+   | 13.0-37.16+  | 
-| [trafficPolicy.tls.caCertificates](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#TLSSettings)                           | 1.0.0+           | 13.0-37.16+  | 
-| [trafficPolicy.tls.sni](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#TLSSettings)                                      |  1.0.0+         | 13.0-37.16+  | 
-| [host](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#DestinationRule) | 1.0.0+         | 13.0-37.16+  | 
-| [subsets](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#Subset)    | 1.0.0+      | 13.0-37.16+  | 
-| [outlierDetection.consecutiveGatewayErrors](https://istio.io/docs/reference/config/networking/destination-rule/#OutlierDetection) | 1.1.0+ | 13.0-41.28+  | 
-| [outlierDetection.interval](https://istio.io/docs/reference/config/networking/destination-rule/#OutlierDetection) | 1.1.0+ | 13.0-41.28 +  | 
-| [outlierDetection.baseEjectionTime](https://istio.io/docs/reference/config/networking/destination-rule/#OutlierDetection) | 1.1.0+ | 13.0-41.28 +  | 
+| [trafficPolicy.connectionPool.tcp.maxConnections](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#ConnectionPoolSettings-TCPSettings)          | 1.0.0+ | 13.0–37.16+  |
+| [trafficPolicy.connectionPool.http.http2MaxRequests](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#ConnectionPoolSettings-HTTPSettings)       | 1.0.0+ | 13.0–37.16+ | 
+| [trafficPolicy.connectionPool.http.maxRequestsPerConnection](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#ConnectionPoolSettings-HTTPSettings) | 1.0.0+ | 13.0–37.16+  |
+| [trafficPolicy.loadBalancer.simple = ROUND_ROBIN](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#LoadBalancerSettings-SimpleLB)           | 1.0.0+ | 13.0–37.16+  | 
+| [trafficPolicy.loadBalancer.simple = LEAST_CONN](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#LoadBalancerSettings-SimpleLB)          | 1.0.0+                     | 13.0–37.16+  | 
+| [trafficPolicy.loadBalancer.simple = RANDOM](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#LoadBalancerSettings-SimpleLB)               | 1.0.0+          | 13.0–37.16+  | 
+| [trafficPolicy.loadBalancer.consistentHash.httpHeaderName](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#LoadBalancerSettings-ConsistentHashLB)  | 1.0.0+  | 13.0–37.16+  | 
+| [trafficPolicy.loadBalancer.consistentHash.httpCookie.name](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#LoadBalancerSettings-ConsistentHashLB) | 1.0.0+   | 13.0–37.16+  | 
+| [trafficPolicy.loadBalancer.consistentHash.httpCookie.ttl](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#LoadBalancerSettings-ConsistentHashLB-HTTPCookie)   |  1.0.0+ | 13.0–37.16+  | 
+| [trafficPolicy.loadBalancer.consistentHash.useSourceIp](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#LoadBalancerSettings-ConsistentHashLB)      | 1.0.0+     | 13.0–37.16+  | 
+| [trafficPolicy.tls.mode = DISABLE](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#TLSSettings-TLSmode)                          | 1.0.0+  | 13.0–37.16+  | 
+| [trafficPolicy.tls.mode = SIMPLE](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#TLSSettings-TLSmode)                         | 1.0.0+   | 13.0–37.16+  | 
+| [trafficPolicy.tls.mode = MUTUAL](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#TLSSettings-TLSmode)                           | 1.0.0+    | 13.0–37.16+  | 
+| [trafficPolicy.tls.mode = ISTIO_MUTUAL](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#TLSSettings-TLSmode)                      | 1.0.0+           | 13.0–37.16+  | 
+| [trafficPolicy.tls.clientCertificate](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#TLSSettings)                         | 1.0.0+          | 13.0–37.16+  | 
+| [trafficPolicy.tls.mode = MUTUAL](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#TLSSettings-TLSmode)                                 | 1.0.0+         | 13.0–37.16+ |
+| [trafficPolicy.tls.privateKey](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#TLSSettings)                               | 1.0.0+   | 13.0–37.16+  | 
+| [trafficPolicy.tls.caCertificates](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#TLSSettings)                           | 1.0.0+           | 13.0–37.16+  | 
+| [trafficPolicy.tls.sni](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#TLSSettings)                                      |  1.0.0+         | 13.0–37.16+  | 
+| [host](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#DestinationRule) | 1.0.0+         | 13.0–37.16+  | 
+| [subsets](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/#Subset)    | 1.0.0+      | 13.0–37.16+  | 
+| [outlierDetection.consecutiveGatewayErrors](https://istio.io/docs/reference/config/networking/destination-rule/#OutlierDetection) | 1.1.0+ | 13.0–41.28+  | 
+| [outlierDetection.interval](https://istio.io/docs/reference/config/networking/destination-rule/#OutlierDetection) | 1.1.0+ | 13.0–41.28 +  | 
+| [outlierDetection.baseEjectionTime](https://istio.io/docs/reference/config/networking/destination-rule/#OutlierDetection) | 1.1.0+ | 13.0–41.28 +  | 
 
 
 ## [Virtual Service](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/)
@@ -43,24 +43,24 @@ The following table describes the virtual service configuration settings support
 
 | Field                       | Istio-adaptor version | Citrix ADC Version |
 |-----------------------------|---------------|---------------------------|
-| [host](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#Destination)                      | 1.0.0+         | 13.0-37.16+  | 
-| [subset](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#Destination)                    | 1.0.0+         | 13.0-37.16+  | 
-| [port](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#Destination)                        | 1.0.0+         | 13.0-37.16+  | 
-| [http.fault.abort.percentage](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPFaultInjection-Abort) | 1.0.0+         | 13.0-37.16+  | 
-| [http.fault.abort.httpStatus](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPFaultInjection-Abort) | 1.0.0+          | 13.0-37.16+  | 
-| [http.match.uri](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPMatchRequest)             | 1.0.0+                 | 13.0-37.16+  | 
-| [http.match.scheme](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPMatchRequest)          | 1.0.0+                  | 13.0-37.16+  | 
-| [http.match.method](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPMatchRequest)          | 1.0.0+                  | 13.0-37.16+  | 
-| [http.match.authority](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPMatchRequest)        | 1.0.0+                  | 13.0-37.16+  | 
-| [http.match.headers](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPMatchRequest)          | 1.0.0+                | 13.0-37.16+  | 
-| [http.match.port](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPMatchRequest)            | 1.0.0+                  |13.0-37.16+  | 
-| [http.redirect.uri](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPRedirect)           | 1.0.0+                     | 13.0-37.16+  | 
-| [http.redirect.authority](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPRedirect)     | 1.0.0+                   | 13.0-37.16+  | 
-| [http.rewrite.uri](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPRewrite)          | 1.0.0+              |13.0-37.16+  | 
-| [http.rewrite.authority](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPRewrite)       | 1.0.0+         | 13.0-37.16+  | 
-| [tcp.route.destination](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#TCPRoute)         | 1.0.0+         | 13.0-37.16+  | 
-| [tcp.route.weight](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#TCPRoute)         | 1.0.0+         | 13.0-37.16+  | 
-| [http.route.mirror](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute) | 1.2.0+ | 13.0-47.22+  | 
+| [host](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#Destination)                      | 1.0.0+         | 13.0–37.16+  | 
+| [subset](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#Destination)                    | 1.0.0+         | 13.0–37.16+  | 
+| [port](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#Destination)                        | 1.0.0+         | 13.0–37.16+  | 
+| [http.fault.abort.percentage](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPFaultInjection-Abort) | 1.0.0+         | 13.0–37.16+  | 
+| [http.fault.abort.httpStatus](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPFaultInjection-Abort) | 1.0.0+          | 13.0–37.16+  | 
+| [http.match.uri](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPMatchRequest)             | 1.0.0+                 | 13.0–37.16+  | 
+| [http.match.scheme](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPMatchRequest)          | 1.0.0+                  | 13.0–37.16+  | 
+| [http.match.method](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPMatchRequest)          | 1.0.0+                  | 13.0–37.16+  | 
+| [http.match.authority](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPMatchRequest)        | 1.0.0+                  | 13.0–37.16+  | 
+| [http.match.headers](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPMatchRequest)          | 1.0.0+                | 13.0–37.16+  | 
+| [http.match.port](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPMatchRequest)            | 1.0.0+                  |13.0–37.16+  | 
+| [http.redirect.uri](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPRedirect)           | 1.0.0+                     | 13.0–37.16+  | 
+| [http.redirect.authority](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPRedirect)     | 1.0.0+                   | 13.0–37.16+  | 
+| [http.rewrite.uri](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPRewrite)          | 1.0.0+              |13.0–37.16+  | 
+| [http.rewrite.authority](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPRewrite)       | 1.0.0+         | 13.0–37.16+  | 
+| [tcp.route.destination](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#TCPRoute)         | 1.0.0+         | 13.0–37.16+  | 
+| [tcp.route.weight](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/#TCPRoute)         | 1.0.0+         | 13.0–37.16+  | 
+| [http.route.mirror](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute) | 1.2.0+ | 13.0–47.22+  | 
 
 **Note:** [http.route.mirrorPercentage](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute) will be supported in next Release
 
@@ -71,31 +71,31 @@ Gateway specification describes a set of ports that should be exposed, the type 
 
 | Field                                 | Istio-adaptor version | Citrix ADC Version |
 |---------------------------------------|---------------|-----------------------------|
-| [gateway.servers.port.number](https://istio.io/docs/reference/config/networking/v1alpha3/gateway/#Port)          | 1.0.0+         | 13.0-37.16+  | 
-| [gateway.servers.port.protocol](https://istio.io/docs/reference/config/networking/v1alpha3/gateway/#Port)        | 1.0.0+         | 13.0-37.16+  |
-| [gateway.servers.port.name](https://istio.io/docs/reference/config/networking/v1alpha3/gateway/#Port)            | 1.0.0+         | 13.0-37.16+  |
-| [gateway.servers.hosts](https://istio.io/docs/reference/config/networking/v1alpha3/gateway/#Server)     | 1.0.0+         |13.0-37.16+  | 
-| [gateway.servers.tls.serverCertificate](https://istio.io/docs/reference/config/networking/v1alpha3/gateway/#Server-TLSOptions) | 1.0.0+         | 13.0-37.16+  | 
-| [gateway.servers.tls.privateKey](https://istio.io/docs/reference/config/networking/v1alpha3/gateway/#Server-TLSOptions)        | 1.0.0+         | 13.0-37.16+  | 
-| [gateway.servers.tls.caCertificates](https://istio.io/docs/reference/config/networking/v1alpha3/gateway/#Server-TLSOptions)    | 1.0.0+         |13.0-37.16+  | 
-| [gateway.servers.tls.credentialName](https://istio.io/docs/reference/config/networking/v1alpha3/gateway/#Server-TLSOptions)   | 1.0.0+ |13.0-37.16+  | 
-| [gateway.servers.tls.mode.SIMPLE](https://istio.io/docs/reference/config/networking/v1alpha3/gateway/#Server-TLSOptions-TLSmode)       | 1.0.0+  | 13.0-37.16+  | 
-| [gateway.servers.tls.mode.MUTUAL](https://istio.io/docs/reference/config/networking/v1alpha3/gateway/#Server-TLSOptions-TLSmode)  | 1.0.0+        |13.0-37.16+  | 
+| [gateway.servers.port.number](https://istio.io/docs/reference/config/networking/v1alpha3/gateway/#Port)          | 1.0.0+         | 13.0–37.16+  | 
+| [gateway.servers.port.protocol](https://istio.io/docs/reference/config/networking/v1alpha3/gateway/#Port)        | 1.0.0+         | 13.0–37.16+  |
+| [gateway.servers.port.name](https://istio.io/docs/reference/config/networking/v1alpha3/gateway/#Port)            | 1.0.0+         | 13.0–37.16+  |
+| [gateway.servers.hosts](https://istio.io/docs/reference/config/networking/v1alpha3/gateway/#Server)     | 1.0.0+         |13.0–37.16+  | 
+| [gateway.servers.tls.serverCertificate](https://istio.io/docs/reference/config/networking/v1alpha3/gateway/#Server-TLSOptions) | 1.0.0+         | 13.0–37.16+  | 
+| [gateway.servers.tls.privateKey](https://istio.io/docs/reference/config/networking/v1alpha3/gateway/#Server-TLSOptions)        | 1.0.0+         | 13.0–37.16+  | 
+| [gateway.servers.tls.caCertificates](https://istio.io/docs/reference/config/networking/v1alpha3/gateway/#Server-TLSOptions)    | 1.0.0+         |13.0–37.16+  | 
+| [gateway.servers.tls.credentialName](https://istio.io/docs/reference/config/networking/v1alpha3/gateway/#Server-TLSOptions)   | 1.0.0+ |13.0–37.16+  | 
+| [gateway.servers.tls.mode.SIMPLE](https://istio.io/docs/reference/config/networking/v1alpha3/gateway/#Server-TLSOptions-TLSmode)       | 1.0.0+  | 13.0–37.16+  | 
+| [gateway.servers.tls.mode.MUTUAL](https://istio.io/docs/reference/config/networking/v1alpha3/gateway/#Server-TLSOptions-TLSmode)  | 1.0.0+        |13.0–37.16+  | 
 
 
 ## [Service Entry](https://istio.io/docs/reference/config/networking/v1alpha3/service-entry/)
 
-You can use service entry to enable adding additional entries into Istio’s internal service registry. Once you enable it, auto-discovered services in the mesh can access or route to these manually specified services.
+You can use the service entry to enable adding more entries into Istio’s internal service registry. Once you enable it, auto-discovered services in the mesh can access or route to these manually specified services.
 
 | Field                               | Istio-adaptor version |  Citrix ADC Version |
 |-------------------------------------|-----------------------|--------------------- |
-| [serviceentry.hosts](https://istio.io/docs/reference/config/networking/v1alpha3/service-entry/#ServiceEntry)                | 1.0.0+         | 13.0-37.16+  | 
-| [serviceentry.ports](https://istio.io/docs/reference/config/networking/v1alpha3/service-entry/#ServiceEntry)               | 1.0.0+         | 13.0-37.16+  | 
-| [serviceentry.location.MESH_EXTERNAL](https://istio.io/docs/reference/config/networking/v1alpha3/service-entry/#ServiceEntry-Location) | 1.0.0+         |13.0-37.16+  | 
-| [serviceentry.location.MESH_INTERNAL](https://istio.io/docs/reference/config/networking/v1alpha3/service-entry/#ServiceEntry-Location) | 1.0.0+         |13.0-37.16+  | 
-| [serviceentry.resolution.DNS](https://istio.io/docs/reference/config/networking/v1alpha3/service-entry/#ServiceEntry-Resolution)       | 1.0.0+         |13.0-37.16+  | 
-| [serviceentry.exportTo](https://istio.io/docs/reference/config/networking/v1alpha3/service-entry/#ServiceEntry)  | 1.0.0+ | 13.0-37.16+  | 
-| [serviceentry-endpoint.weight](https://istio.io/docs/reference/config/networking/service-entry/#ServiceEntry-Location) | 1.2.0+ |13.0-47.22+  | 
+| [serviceentry.hosts](https://istio.io/docs/reference/config/networking/v1alpha3/service-entry/#ServiceEntry)                | 1.0.0+         | 13.0–37.16+  | 
+| [serviceentry.ports](https://istio.io/docs/reference/config/networking/v1alpha3/service-entry/#ServiceEntry)               | 1.0.0+         | 13.0–37.16+  | 
+| [serviceentry.location.MESH_EXTERNAL](https://istio.io/docs/reference/config/networking/v1alpha3/service-entry/#ServiceEntry-Location) | 1.0.0+         |13.0–37.16+  | 
+| [serviceentry.location.MESH_INTERNAL](https://istio.io/docs/reference/config/networking/v1alpha3/service-entry/#ServiceEntry-Location) | 1.0.0+         |13.0–37.16+  | 
+| [serviceentry.resolution.DNS](https://istio.io/docs/reference/config/networking/v1alpha3/service-entry/#ServiceEntry-Resolution)       | 1.0.0+         |13.0–37.16+  | 
+| [serviceentry.exportTo](https://istio.io/docs/reference/config/networking/v1alpha3/service-entry/#ServiceEntry)  | 1.0.0+ | 13.0–37.16+  | 
+| [serviceentry-endpoint.weight](https://istio.io/docs/reference/config/networking/service-entry/#ServiceEntry-Location) | 1.2.0+ |13.0–47.22+  | 
 
 ## [Authentication Policy](https://istio.io/docs/reference/config/istio.authentication.v1alpha1/)
 
@@ -103,19 +103,17 @@ Using authentication policies you can specify authentication requirements for se
 
 | Field                          | Istio-adaptor version| Citrix ADC Version|
 |--------------------------------|----------------------|---------------------| 
-| [jwt](https://istio.io/docs/reference/config/istio.authentication.v1alpha1/#OriginAuthenticationMethod)| 1.0.0+ |13.0-37.16+  | 
-| [jwt.issuer](https://istio.io/docs/reference/config/istio.authentication.v1alpha1/#OriginAuthenticationMethod) | 1.0.0+ | 13.0-37.16+  | 
-| [jwt.audiences](https://istio.io/docs/reference/config/istio.authentication.v1alpha1/#Jwt) | 1.0.0+ |13.0-38.13+|
-| [jwt.jwksUri](https://istio.io/docs/reference/config/istio.authentication.v1alpha1/#Jwt) | 1.0.0+ | 13.0-37.16+  |
-| [jwt.jwtHeaders](https://istio.io/docs/reference/config/istio.authentication.v1alpha1/#Jwt) | 1.0.0+  |13.0-38.13+|
-| [jwt.jwtParams](https://istio.io/docs/reference/config/istio.authentication.v1alpha1/#Jwt)| 1.0.0+ |13.0-38.13+|
-| [jwt.triggerRules.excludedPaths](https://istio.io/docs/reference/config/istio.authentication.v1alpha1/#Jwt-TriggerRule) | 1.0.0+ |13.0-37.16+  |
-| [jwt.triggerRules.includedPaths](https://istio.io/docs/reference/config/istio.authentication.v1alpha1/#Jwt-TriggerRule) | 1.0.0+ |13.0-37.16+  | 
-| [mtls](https://istio.io/docs/reference/config/istio.authentication.v1alpha1/#PeerAuthenticationMethod) | 1.0.0+  |13.0-37.16+  | 
-| [mutualtls.mode.strict](https://istio.io/docs/reference/config/istio.authentication.v1alpha1/#MutualTls-Mode) | 1.0.0+ |13.0-37.16+  | 
-
-
+| [jwt](https://istio.io/docs/reference/config/istio.authentication.v1alpha1/#OriginAuthenticationMethod)| 1.0.0+ |13.0–37.16+  | 
+| [jwt.issuer](https://istio.io/docs/reference/config/istio.authentication.v1alpha1/#OriginAuthenticationMethod) | 1.0.0+ | 13.0–37.16+  | 
+| [jwt.audiences](https://istio.io/docs/reference/config/istio.authentication.v1alpha1/#Jwt) | 1.0.0+ |13.0–38.13+|
+| [jwt.jwksUri](https://istio.io/docs/reference/config/istio.authentication.v1alpha1/#Jwt) | 1.0.0+ | 13.0–37.16+  |
+| [jwt.jwtHeaders](https://istio.io/docs/reference/config/istio.authentication.v1alpha1/#Jwt) | 1.0.0+  |13.0–38.13+|
+| [jwt.jwtParams](https://istio.io/docs/reference/config/istio.authentication.v1alpha1/#Jwt)| 1.0.0+ |13.0–38.13+|
+| [jwt.triggerRules.excludedPaths](https://istio.io/docs/reference/config/istio.authentication.v1alpha1/#Jwt-TriggerRule) | 1.0.0+ |13.0–37.16+  |
+| [jwt.triggerRules.includedPaths](https://istio.io/docs/reference/config/istio.authentication.v1alpha1/#Jwt-TriggerRule) | 1.0.0+ |13.0–37.16+  | 
+| [mtls](https://istio.io/docs/reference/config/istio.authentication.v1alpha1/#PeerAuthenticationMethod) | 1.0.0+  |13.0–37.16+  | 
+| [mutualtls.mode.strict](https://istio.io/docs/reference/config/istio.authentication.v1alpha1/#MutualTls-Mode) | 1.0.0+ |13.0–37.16+  | 
 
 # Limitations
 
-Citrix servicemesh solution currently does not support Mixer interaction. Thus, features associated with the Mixer are not supported. Citrix has plans to support Mixer integration in future releases.
+Citrix service mesh solution currently does not support Mixer interaction. Thus, features associated with the Mixer are not supported. 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ Citrix ADC can be integrated with Istio in two ways:
 - Citrix ADC CPX, MPX, or VPX as an Ingress Gateway to the service mesh.
 - Citrix ADC CPX as a sidecar proxy with application containers in the service mesh.
 
-## Citrix ADC as an ingress gateway for Istio
+## Citrix ADC as an Ingress Gateway for Istio
 
 An Istio ingress gateway acts as an entry point for the incoming traffic and secures and controls access to the service mesh from outside. It also performs routing and load balancing. Citrix ADC CPX, MPX, or VPX can be deployed as an ingress gateway to the Istio service mesh.
 


### PR DESCRIPTION
Fixed formatting and performed minor language edits for files in the docs folder to meet the requirements of developer docs.
Removed the TOC at the beginning of architecture.md because developer docs autogenerate TOC on the left navigation. 
